### PR TITLE
Fix | Replace old reference to GitHub Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Para contribuir al sitio:
 - Crear un fork
 - Editar o crear archivos markdown en la carpeta `./src`
 - Commitear y pushear a tu fork.
-- Crear un pull request contra `development` de `https://github.com/RustArgentina/rustargentina.github.io`. Es importante que sea contra esta branch y no otra.
+- Crear un pull request contra `development` de `https://github.com/rust-lang-ar/rust-lang-ar.github.io`. Es importante que sea contra esta branch y no otra.
 
 ## Notas
 

--- a/src/presentacion.md
+++ b/src/presentacion.md
@@ -1,7 +1,7 @@
 # Presentación
 
 <center>
-	<img alt="Logo" src="https://raw.githubusercontent.com/RustArgentina/RustArgentina.github.io/development/src/img/logo.jpeg"/>
+	<img alt="Logo" src="https://raw.githubusercontent.com/rust-lang-ar/rust-lang-ar.github.io/development/src/img/logo.jpeg"/>
 </center>
 
 La comunidad de Rust en Argentina es pequeña pero creciente.


### PR DESCRIPTION
Replaces old references to GitHub Pages with the need address